### PR TITLE
add format property to time-map

### DIFF
--- a/lib/travel_time/client.rb
+++ b/lib/travel_time/client.rb
@@ -65,14 +65,14 @@ module TravelTime
       perform_request { connection.get('geocoding/reverse', query) }
     end
 
-    def time_map(departure_searches: nil, arrival_searches: nil, unions: nil, intersections: nil)
+    def time_map(departure_searches: nil, arrival_searches: nil, unions: nil, intersections: nil, format: nil)
       payload = {
         departure_searches: departure_searches,
         arrival_searches: arrival_searches,
         unions: unions,
         intersections: intersections
       }.compact
-      perform_request { connection.post('time-map', payload) }
+      perform_request { connection.post('time-map', payload, {'Accept' => format}) }
     end
 
     def time_filter(locations:, departure_searches: nil, arrival_searches: nil)

--- a/lib/travel_time/client.rb
+++ b/lib/travel_time/client.rb
@@ -72,7 +72,7 @@ module TravelTime
         unions: unions,
         intersections: intersections
       }.compact
-      perform_request { connection.post('time-map', payload, {'Accept' => format}) }
+      perform_request { connection.post('time-map', payload, { 'Accept' => format }) }
     end
 
     def time_filter(locations:, departure_searches: nil, arrival_searches: nil)

--- a/lib/travel_time/version.rb
+++ b/lib/travel_time/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TravelTime
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Add `Accept` header to time-map. 

Behaviour: 

- return response in requested format when header is present
- return response in default format if header is not present
- return response in default format if header is invalid
- api error if requested unsupported format

See some examples bellow: 

![image](https://user-images.githubusercontent.com/59711277/197731856-48d50254-42c1-459c-953c-988d1c548f5d.png)

![image](https://user-images.githubusercontent.com/59711277/197731036-de83ed1b-d117-4497-b36f-559e6edddcef.png)

![image](https://user-images.githubusercontent.com/59711277/197731069-55b4f1e6-2654-4b17-b718-9f301fab1a25.png)

![image](https://user-images.githubusercontent.com/59711277/197731094-33f32881-9a42-4ddd-a484-74c6e42a0f3b.png)

![image](https://user-images.githubusercontent.com/59711277/197731122-c91d6a8a-99f4-4a04-a282-07e6c84f910c.png)
