### PR TITLE
update geocoding properties

### DIFF
--- a/lib/travel_time/client.rb
+++ b/lib/travel_time/client.rb
@@ -43,11 +43,13 @@ module TravelTime
       perform_request { connection.post('supported-locations', { locations: locations }) }
     end
 
-    def geocoding(query:, within_country: nil, exclude: nil, limit: nil, force_postcode: nil, bounds: nil)
+    def geocoding(query:, within_country: nil, format_name: nil, exclude: nil, limit: nil, force_postcode: nil,
+                  bounds: nil)
       query = {
         query: query,
         'within.country': within_country,
-        'exclude.location.types': exclude,
+        'format.name': format_name,
+        'format.exclude.country': exclude,
         limit: limit,
         'force.add.postcode': force_postcode,
         bounds: bounds ? bounds.join(',') : nil

--- a/lib/travel_time/version.rb
+++ b/lib/travel_time/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TravelTime
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
- remove deprecated `exclude.location.types` property
- add `format.name` and `format.exclude.country` properties