### PR TITLE
Relax version constraint for dry-configurable

### DIFF
--- a/travel_time.gemspec
+++ b/travel_time.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/traveltime-dev/traveltime-sdk-ruby'
   spec.metadata['changelog_uri'] = 'https://github.com/traveltime-dev/traveltime-sdk-ruby/releases'
 
-  spec.add_dependency 'dry-configurable', '~> 0.14.0'
+  spec.add_dependency 'dry-configurable', '< 2.0'
   spec.add_dependency 'faraday', '>= 1.10', '< 3.0'
   spec.add_dependency 'google-protobuf', '>= 3.21', '< 3.21.9'
   spec.add_dependency 'ruby-limiter', '~> 2.2.2'


### PR DESCRIPTION
## Summary

The `dry` gems family has recently hit v1.0.
Latest ruby versions (e.g. 3.2) are only supported in those latest versions.
We currently lock `dry-configurable` to `~> 0.14.0`, with doesn't allow to update it.
This PR relaxes that constaint so that all versions up to 2.0 (excluded) can be installed.

## Additional Details

Looking at the [release log](https://github.com/dry-rb/dry-configurable/releases), there should be no breaking changes to the gem functionality from 0.14 to 1.0 👍 
