### PR TITLE
CI: disable persist-credentials for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
@@ -41,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It is a possible security issue.
We do not want to persist credentials in the repo and thus exposing those to further steps.

References:

* https://github.com/actions/checkout/issues/485#issuecomment-1197047674
* https://github.com/azat/chdig/pull/67